### PR TITLE
Fix: Let TpchSanitizer drop views in case the referred "table" was a view

### DIFF
--- a/mysite/unmasque/src/pipeline/abstract/TpchSanitizer.py
+++ b/mysite/unmasque/src/pipeline/abstract/TpchSanitizer.py
@@ -1,4 +1,5 @@
-from mysite.unmasque.refactored.util.common_queries import get_restore_name, drop_table, alter_table_rename_to
+from typing import Literal
+from mysite.unmasque.refactored.util.common_queries import drop_view, get_restore_name, drop_table, alter_table_rename_to
 
 
 class TpchSanitizer:
@@ -20,6 +21,16 @@ class TpchSanitizer:
             "WHERE table_schema = '" + self.connectionHelper.config.schema + "' and TABLE_CATALOG= '" \
             + self.connectionHelper.db + "'"
 
+    def is_view_or_table(self, table_or_view_name: str) -> Literal['view', 'table']:
+        # Reference: https://www.postgresql.org/docs/current/infoschema-tables.html
+        check_query = "select table_type " + self.from_where_catalog() + f" and table_name = '{table_or_view_name}'"
+        res, _ = self.connectionHelper.execute_sql_fetchall(check_query)
+
+        if res[0][0] == 'VIEW':
+            return 'view'
+        else:
+            return 'table'
+
     def begin_transaction(self):
         self.connectionHelper.execute_sql(["BEGIN;"])
 
@@ -39,8 +50,9 @@ class TpchSanitizer:
                                                                + " and table_name like '%_restore';")
         for row in res:
             table = row[0]
+            drop_fn = drop_table if self.is_view_or_table(table) == 'table' else drop_view
             restore_name = get_restore_name(table)
-            self.connectionHelper.execute_sql([drop_table(table), alter_table_rename_to(restore_name, table)])
+            self.connectionHelper.execute_sql([drop_fn(table), alter_table_rename_to(restore_name, table)])
 
         res, desc = self.connectionHelper.execute_sql_fetchall("SELECT table_name"
                                                                + self.from_where_catalog()


### PR DESCRIPTION
There is a rare chance that the user sends a SIGINT or SIGTERM signal (via Ctrl + C or the `kill` command) during the `ViewMinimizer` stage of the pipeline. In `ViewMinimizer` a table is renamed and a view of the same name is created instead of a table, thus execution of the drop table query fails. The stack trace of the same is posted below. This PR adds an extra check to make sure that the referred "table" is a view and executes the correct drop command.

Stack trace:
```
Database needs to be restored!
Executable could not be run. Error: "orders" is not a table
HINT:  Use DROP VIEW to remove a view.

Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/src/main_cmd.py", line 38, in <module>
    eq, t = ExtractionPipeLine.extract(hq)
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/src/pipeline/ExtractionPipeLine.py", line 50, in extract
    check = vm.doJob(query)
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/refactored/abstract/ExtractorBase.py", line 27, in doJob
    self.result = self.doActualJob(args)
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/refactored/view_minimizer.py", line 45, in doActualJob
    return self.reduce_Database_Instance(query,
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/refactored/view_minimizer.py", line 108, in reduce_Database_Instance
    core_sizes = self.do_binary_halving(core_sizes, query, tabname, rctid, view_name)
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/refactored/view_minimizer.py", line 59, in do_binary_halving
    end_ctid, start_ctid = self.create_view_execute_app_drop_view(end_ctid, mid_ctid1, mid_ctid2, query,
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/refactored/view_minimizer.py", line 81, in create_view_execute_app_drop_view
    new_result = self.app.doJob(query)
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/refactored/abstract/ExtractorBase.py", line 27, in doJob
    self.result = self.doActualJob(args)
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/refactored/executable.py", line 36, in doActualJob
    raise error
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/refactored/executable.py", line 28, in doActualJob
    res, description = self.connectionHelper.execute_sql_fetchall(query)
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/src/util/ConnectionHelper.py", line 117, in execute_sql_fetchall
    cur.execute(sql)
  File "/usr/lib/python3.10/encodings/utf_8.py", line 15, in decode
    def decode(input, errors='strict'):
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/src/main_cmd.py", line 14, in signal_handler
    sanitizer.doJob()
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/src/pipeline/abstract/TpchSanitizer.py", line 43, in doJob
    self.connectionHelper.execute_sql([drop_table(table), alter_table_rename_to(restore_name, table)])
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/src/util/ConnectionHelper.py", line 92, in execute_sql
    cus_execute_sqls(cur, sqls)
  File "/home/snooze/iisc/sem1/dbms/project/UN1/mysite/unmasque/src/util/ConnectionHelper.py", line 12, in cus_execute_sqls
    cur.execute(sql)
psycopg2.errors.WrongObjectType: "orders" is not a table
HINT:  Use DROP VIEW to remove a view.
``` 